### PR TITLE
Add support for configuring Docker with ENV

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,18 +2,21 @@ plugins {
     id 'java'
     id 'signing'
     id 'com.gradle.plugin-publish' version '1.3.1'
-    id "io.freefair.lombok" version "8.13.1"
+    id "io.freefair.lombok" version "8.14"
 }
 
-group 'run.halo.gradle'
+group = 'run.halo.gradle'
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    options.release = 17
+}
 
 repositories {
     mavenCentral()
@@ -52,7 +55,7 @@ ext {
     lang3 = '3.12.0'
     semver4j = '0.9.0'
     asm = '9.8'
-    dockerJava = '3.3.0'
+    dockerJava = '3.5.3'
     jsonPatch = '1.13'
     openApiGenerator = '7.7.0'
 }
@@ -75,7 +78,7 @@ dependencies {
     implementation "com.github.zafarkhaja:java-semver:$semver4j"
     implementation "org.ow2.asm:asm:$asm"
     implementation "org.ow2.asm:asm-commons:$asm"
-    implementation 'commons-io:commons-io:2.11.0'
+    implementation 'commons-io:commons-io:2.19.0'
     implementation "com.github.java-json-tools:json-patch:$jsonPatch"
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'

--- a/src/main/java/run/halo/gradle/docker/DockerClientService.java
+++ b/src/main/java/run/halo/gradle/docker/DockerClientService.java
@@ -81,7 +81,9 @@ public abstract class DockerClientService
         // Create configuration
         DefaultDockerClientConfig.Builder dockerClientConfigBuilder =
             DefaultDockerClientConfig.createDefaultConfigBuilder();
-        dockerClientConfigBuilder.withDockerHost(dockerUrl);
+        if (dockerUrl != null && !dockerUrl.isBlank()) {
+            dockerClientConfigBuilder.withDockerHost(dockerUrl);
+        }
 
         if (dockerCertPath != null) {
             String canonicalCertPath;
@@ -121,6 +123,10 @@ public abstract class DockerClientService
      * @return Docker host URL as string
      */
     private String getDockerHostUrl(DockerClientConfiguration dockerClientConfiguration) {
+        if (dockerClientConfiguration.getUrl() == null
+            || dockerClientConfiguration.getUrl().isBlank()) {
+            return null;
+        }
         String url =
             thingOrProperty(objects.property(String.class), dockerClientConfiguration.getUrl(),
                 getParameters().getUrl()).map(String::toLowerCase).get();

--- a/src/main/java/run/halo/gradle/docker/DockerCreateContainer.java
+++ b/src/main/java/run/halo/gradle/docker/DockerCreateContainer.java
@@ -8,10 +8,12 @@ import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.InspectContainerCmd;
 import com.github.dockerjava.api.exception.DockerException;
+import com.github.dockerjava.api.model.AccessMode;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.SELContext;
 import com.github.dockerjava.api.model.Volume;
 import java.io.File;
 import java.io.IOException;
@@ -180,7 +182,6 @@ public class DockerCreateContainer extends AbstractOpenApiDocsTask {
         if (platform.getOrNull() != null) {
             containerCommand.withPlatform(platform.get());
         }
-        containerCommand.withCmd("--rm");
 
         String pluginName = getPluginExtension().getPluginName();
         Integer port = haloExtension.getPort();
@@ -230,19 +231,30 @@ public class DockerCreateContainer extends AbstractOpenApiDocsTask {
         File projectDir = getProject().getLayout().getBuildDirectory().getAsFile().get();
 
         List<Bind> binds = new ArrayList<>();
-        binds.add(new Bind(projectDir.toString(),
-            new Volume(HaloServerConfigure.buildPluginDestPath(pluginName) + "build")));
+        binds.add(new Bind(
+            projectDir.toString(),
+            new Volume(HaloServerConfigure.buildPluginDestPath(pluginName) + "build"),
+            AccessMode.ro, SELContext.shared
+        ));
         if (pluginWorkplaceDir.isPresent()) {
             var sourceDir = pluginWorkplaceDir.getAsFile().get().getAbsolutePath();
-            binds.add(new Bind(sourceDir, new Volume(haloWorkDir())));
+            binds.add(new Bind(
+                sourceDir,
+                new Volume(haloWorkDir()),
+                AccessMode.rw,
+                SELContext.shared
+            ));
         }
 
         var pluginConfigYaml = getPluginExtension().getConfigurationPropertiesFile()
             .getAsFile().getOrNull();
         if (pluginConfigYaml != null && Files.exists(pluginConfigYaml.toPath())) {
-            binds.add(new Bind(pluginConfigYaml.getAbsolutePath(),
-                new Volume(
-                    buildPluginConfigYamlPath(haloExtension.getServerWorkDir(), pluginName))));
+            binds.add(new Bind(
+                pluginConfigYaml.getAbsolutePath(),
+                new Volume(buildPluginConfigYamlPath(haloExtension.getServerWorkDir(), pluginName)),
+                AccessMode.ro,
+                SELContext.shared
+            ));
         }
 
         hostConfig.withBinds(binds);

--- a/src/main/java/run/halo/gradle/extension/HaloExtension.java
+++ b/src/main/java/run/halo/gradle/extension/HaloExtension.java
@@ -3,7 +3,6 @@ package run.halo.gradle.extension;
 import javax.annotation.Nonnull;
 import lombok.Data;
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.SystemUtils;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.file.RegularFileProperty;
@@ -90,18 +89,12 @@ public class HaloExtension {
 
     public static class Docker {
 
-        static final String DEFAULT_DOCKER_HOST = "unix:///var/run/docker.sock";
-
-        static final String WINDOWS_DEFAULT_DOCKER_HOST = "npipe:////./pipe/docker_engine";
-
         private final Property<String> url;
 
         private final Property<String> apiVersion;
 
         public Docker(ObjectFactory objectFactory) {
             url = objectFactory.property(String.class);
-            url.convention(getDefaultDockerUrl());
-
             apiVersion = objectFactory.property(String.class);
         }
 
@@ -130,8 +123,5 @@ public class HaloExtension {
             this.apiVersion.set(apiVersion);
         }
 
-        String getDefaultDockerUrl() {
-            return SystemUtils.IS_OS_WINDOWS ? WINDOWS_DEFAULT_DOCKER_HOST : DEFAULT_DOCKER_HOST;
-        }
     }
 }


### PR DESCRIPTION
This PR removes the default URL of Docker client configuration, because the DefaultDockerClientConfig natively can resolve Docker client configuration from environments or properties.

> https://github.com/docker-java/docker-java/blob/main/docs/getting_started.md

If you are using Podman, you can make it work according to the following commands:

```bash
systemctl start podman --user
export DOCKER_HOST=unix://${XDG_RUNTIME_DIR}/podman/podman.sock
./gradlew haloServer
```

```release-note
支持通过环境变量配置 Docker 客户端
```

