### PR TITLE
[codex] Store haloServer container state outside build dir

### DIFF
--- a/src/main/java/run/halo/gradle/HaloDevtoolsPlugin.java
+++ b/src/main/java/run/halo/gradle/HaloDevtoolsPlugin.java
@@ -235,21 +235,31 @@ public class HaloDevtoolsPlugin implements Plugin<Project> {
 
             Provider<HaloServerBuildOperationListener> haloServerBuildOperationListenerProvider =
                 project.getGradle().getSharedServices()
-                    .registerIfAbsent("halo-server-build-operation-listener",
+                    .registerIfAbsent(
+                        "halo-server-build-operation-listener-" + safeProjectPath(project),
                         HaloServerBuildOperationListener.class,
                         builderServiceSpec -> {
                             builderServiceSpec.parameters(parameters -> {
                                 parameters.getDockerClientService().set(serviceProvider);
-                                // TODO use a better way to get container id
-                                File containerIdFile =
-                                    new File(
-                                        project.getLayout().getBuildDirectory().getAsFile().get(),
-                                        ".docker/createHaloContainer-containerId.txt");
-                                parameters.getContainerId().set(containerIdFile);
+                                parameters.getContainerId()
+                                    .set(project.getRootProject().getLayout().getProjectDirectory()
+                                        .file(DockerCreateContainer.containerIdFilePath(
+                                            project.getPath()))
+                                        .getAsFile());
+                                parameters.getSupportedTaskPaths()
+                                    .add(project.getTasks().named(HaloServerTask.TASK_NAME)
+                                        .map(Task::getPath));
+                                parameters.getSupportedTaskPaths()
+                                    .add(project.getTasks().named("watch").map(Task::getPath));
                             });
                         });
             buildEvents.onOperationCompletion(haloServerBuildOperationListenerProvider);
         });
+    }
+
+    private String safeProjectPath(Project project) {
+        String projectPath = project.getPath().replaceFirst("^:", "").replaceAll(":", "_");
+        return StringUtils.defaultIfBlank(projectPath, "root");
     }
 
     private TaskProvider<ReloadPluginTask> configureReloadPluginTask(Project project,

--- a/src/main/java/run/halo/gradle/HaloServerBuildOperationListener.java
+++ b/src/main/java/run/halo/gradle/HaloServerBuildOperationListener.java
@@ -12,6 +12,7 @@ import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationDetails;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -25,9 +26,6 @@ import run.halo.gradle.docker.DockerClientService;
 
 public abstract class HaloServerBuildOperationListener
     implements BuildService<HaloServerBuildOperationListener.Params>, BuildOperationListener {
-
-    private final static Set<String> SUPPORTED_TASK_NAME =
-        Set.of(HaloServerTask.TASK_NAME, "watch");
 
     public interface Params extends BuildServiceParameters {
 
@@ -44,6 +42,13 @@ public abstract class HaloServerBuildOperationListener
          * @return The container id
          */
         Property<File> getContainerId();
+
+        /**
+         * The task paths that should trigger cleanup when completed.
+         *
+         * @return supported task paths
+         */
+        SetProperty<String> getSupportedTaskPaths();
     }
 
     @Override
@@ -62,8 +67,9 @@ public abstract class HaloServerBuildOperationListener
         @Nonnull OperationFinishEvent finishEvent) {
         Object details = buildOperation.getDetails();
         if (details instanceof ExecuteTaskBuildOperationDetails executeTaskDetails) {
-            String name = executeTaskDetails.getTask().getName();
-            if (!SUPPORTED_TASK_NAME.contains(name)) {
+            String path = executeTaskDetails.getTask().getPath();
+            Set<String> supportedTaskPaths = getParameters().getSupportedTaskPaths().get();
+            if (!supportedTaskPaths.contains(path)) {
                 return;
             }
             DockerClientService dockerClientService =

--- a/src/main/java/run/halo/gradle/docker/DockerCreateContainer.java
+++ b/src/main/java/run/halo/gradle/docker/DockerCreateContainer.java
@@ -21,8 +21,12 @@ import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -77,8 +81,7 @@ public class DockerCreateContainer extends AbstractOpenApiDocsTask {
 
     /**
      * Output file containing the container ID of the container created.
-     * Defaults to "$buildDir/.docker/$taskpath-containerId.txt".
-     * If path contains ':' it will be replaced by '_'.
+     * Defaults to "$rootDir/.gradle/halo-devtools/containers/$projectPathHash-containerId.txt".
      */
     @Getter
     @OutputFile
@@ -105,11 +108,25 @@ public class DockerCreateContainer extends AbstractOpenApiDocsTask {
         super();
         containerId.convention(containerIdFile.map(new RegularFileToStringTransformer()));
 
-        String safeTaskPath = getPath().replaceFirst("^:", "").replaceAll(":", "_");
-        containerIdFile.convention(getProject().getLayout().getBuildDirectory()
-            .file(".docker/" + safeTaskPath + "-containerId.txt"));
+        containerIdFile.convention(getProject().getRootProject().getLayout().getProjectDirectory()
+            .file(containerIdFilePath(getProject().getPath())));
 
         getOutputs().upToDateWhen(getUpToDateWhenSpec());
+    }
+
+    public static String containerIdFilePath(String projectPath) {
+        return ".gradle/halo-devtools/containers/" + projectPathHash(projectPath)
+            + "-containerId.txt";
+    }
+
+    static String projectPathHash(String projectPath) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(projectPath.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash, 0, 8);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
     }
 
     private Spec<Task> getUpToDateWhenSpec() {
@@ -164,7 +181,9 @@ public class DockerCreateContainer extends AbstractOpenApiDocsTask {
             final String localContainerName =
                 containerName.getOrNull() == null ? container.getId() : containerName.get();
             log.info("Created container with ID [{}]", localContainerName);
-            Files.writeString(containerIdFile.get().getAsFile().toPath(), container.getId());
+            File targetFile = containerIdFile.get().getAsFile();
+            Files.createDirectories(targetFile.toPath().getParent());
+            Files.writeString(targetFile.toPath(), container.getId());
             Action<? super Object> nextHandler = getNextHandler();
             if (nextHandler != null) {
                 nextHandler.execute(container);

--- a/src/test/java/run/halo/gradle/docker/DockerCreateContainerTest.java
+++ b/src/test/java/run/halo/gradle/docker/DockerCreateContainerTest.java
@@ -1,0 +1,18 @@
+package run.halo.gradle.docker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DockerCreateContainerTest {
+
+    @Test
+    void shouldBuildContainerIdFilePathFromProjectPath() {
+        assertThat(DockerCreateContainer.containerIdFilePath(":"))
+            .isEqualTo(".gradle/halo-devtools/containers/e7ac0786668e0ff0-containerId.txt");
+        assertThat(DockerCreateContainer.containerIdFilePath(":app"))
+            .isEqualTo(".gradle/halo-devtools/containers/fe6d6407b0d4f368-containerId.txt");
+        assertThat(DockerCreateContainer.containerIdFilePath(":plugins:app"))
+            .isEqualTo(".gradle/halo-devtools/containers/ec3dced475b9eeff-containerId.txt");
+    }
+}


### PR DESCRIPTION
## Summary

- Store the Halo development container ID under the root project's `.gradle/halo-devtools/containers/<project-path-hash>-containerId.txt` instead of `build/.docker`.
- Match cleanup triggers by task path instead of task name so subproject tasks such as `:app:haloServer` are handled correctly.
- Register a project-specific cleanup listener to avoid shared-service collisions when the plugin is applied in multiple projects.
- Add unit coverage for root-project and subproject container ID state paths.

## Root Cause

In multi-module plugins where DevTools is applied to a subproject such as `:app`, `createHaloContainer` needs a project-specific container ID state file that survives ordinary `build` directory cleanup. The previous implementation stored the ID under `build/.docker` using a task-path-derived name. That made cleanup fragile in two ways: subproject paths could be resolved incorrectly, and a separate build could remove the state file while `haloServer` was still running.

## Validation

- `./gradlew test`
- Composite-build smoke test with a local multi-module Halo plugin project using this branch and Gradle 8.14:
  - ran `:app:tasks --group "halo server"` successfully
  - ran `:app:haloServer`, confirmed `.gradle/halo-devtools/containers/fe6d6407b0d4f368-containerId.txt` was written
  - confirmed no container ID file was written under `app/build/.docker`
  - interrupted the running Gradle task with `SIGINT`
  - confirmed `docker ps -a --filter name=halo-for-plugin-development` returned no container

## Notes

The smoke test used this repository's Gradle 8.14 wrapper to validate the cleanup behavior against a multi-module project shape.

```release-note
修复结束 ./gradlew haloServer 进程之后，容器可能不会自动删除的问题
```