### PR TITLE
Update README for latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,13 @@ This is a Gradle plugin for building Halo plugins, written in Java.
 
 ## How to Use
 
-Since this is currently a Snapshot version, you need to add the following configuration to the `settings.gradle` file of your project:
-
-```groovy
-pluginManagement {
-    repositories {
-        maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
-        gradlePluginPortal()
-    }
-}
-```
-
-Then, add the following configuration to the `build.gradle` file of your project:
+Add the following configuration to the `build.gradle` file of your project:
 
 ```groovy
 plugins {
     // ...
     // Add this Gradle plugin dependency
-    id "run.halo.plugin.devtools" version "0.0.9"
+    id "run.halo.plugin.devtools" version "0.6.2"
 }
 ```
 
@@ -54,9 +43,14 @@ halo {
     superAdminUsername = 'admin'
     superAdminPassword = 'admin'
     externalUrl = 'http://localhost:8090'
+
+    // Optional. If this block is not configured, the Docker client will use Docker's
+    // default configuration and environment variables such as DOCKER_HOST,
+    // DOCKER_TLS_VERIFY, DOCKER_CERT_PATH, and DOCKER_API_VERSION.
     docker {
         // For Windows, the default is npipe:////./pipe/docker_engine
         url = 'unix:///var/run/docker.sock'
+        // Optional. For most cases this can be left unset.
         apiVersion = '1.42'
     }
 }
@@ -304,7 +298,7 @@ This will publish the plugin to the local Maven repository. Then, add the follow
 ```groovy
 plugins {
     //...
-    id "run.halo.plugin.devtools" version "0.0.10-SNAPSHOT"
+    id "run.halo.plugin.devtools" version "0.6.0-SNAPSHOT"
 }
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,24 +4,13 @@ This is a Gradle plugin for building Halo plugins, written in Java.
 
 ## how to use
 
-由于目前还是 Snapshot 版本，需要在项目的 `settings.gradle` 中添加如下配置：
-
-```groovy
-pluginManagement {
-    repositories {
-        maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
-        gradlePluginPortal()
-    }
-}
-```
-
-然后在项目的 `build.gradle` 中添加如下配置：
+在项目的 `build.gradle` 中添加如下配置：
 
 ```groovy
 plugins {
     // ...
     // 添加此 gradle 插件依赖
-    id "run.halo.plugin.devtools" version "0.0.9"
+    id "run.halo.plugin.devtools" version "0.6.2"
 }
 ```
 
@@ -52,9 +41,13 @@ halo {
     superAdminUsername = 'admin'
     superAdminPassword = 'admin'
     externalUrl = 'http://localhost:8090'
+
+    // 可选。如果不配置此块，Docker client 会使用 Docker 的默认配置和环境变量，
+    // 例如 DOCKER_HOST、DOCKER_TLS_VERIFY、DOCKER_CERT_PATH、DOCKER_API_VERSION。
     docker {
         // windows 默认为 npipe:////./pipe/docker_engine
         url = 'unix:///var/run/docker.sock'
+        // 可选，大多数情况下可以不设置。
         apiVersion = '1.42'
     }
 }
@@ -312,7 +305,7 @@ Listening for transport dt_socket at address: 50781 Attach debugger
 ```groovy
 plugins {
     //...
-    id "run.halo.plugin.devtools" version "0.0.10-SNAPSHOT"
+    id "run.halo.plugin.devtools" version "0.6.0-SNAPSHOT"
 }
 ```
 


### PR DESCRIPTION
## What changed

- Update README installation examples to use the latest released plugin version, `0.6.2`.
- Remove outdated snapshot repository setup from the published-version instructions.
- Document Docker environment variable support in both English and Chinese README files.
- Align the local snapshot example with the current project version, `0.6.0-SNAPSHOT`.

## Validation

- `git diff --check`

No tests were run because this only changes documentation.
