### PR TITLE
Generate unique haloServer container names

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ halo {
     version = '2.9.1'
     superAdminUsername = 'admin'
     superAdminPassword = 'admin'
+    port = 8090
     externalUrl = 'http://localhost:8090'
+    // Optional. By default, the container name is generated from the project
+    // name, root directory, and Gradle project path.
+    // containerName = 'halo-for-plugin-development'
 
     // Optional. If this block is not configured, the Docker client will use Docker's
     // default configuration and environment variables such as DOCKER_HOST,
@@ -57,6 +61,11 @@ halo {
 ```
 
 If needed, you can modify this configuration in `build.gradle`.
+
+When running `haloServer` for multiple plugin projects at the same time, configure
+different `port` and `externalUrl` values for each project. If debug mode is enabled,
+also configure different `debugPort` values. The `containerName` option is only needed
+when you want to use a custom fixed Docker container name.
 
 ### haloServer Task
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -40,7 +40,10 @@ halo {
     version = '2.9.1'
     superAdminUsername = 'admin'
     superAdminPassword = 'admin'
+    port = 8090
     externalUrl = 'http://localhost:8090'
+    // 可选。默认会根据项目名称、根目录和 Gradle project path 自动生成容器名称。
+    // containerName = 'halo-for-plugin-development'
 
     // 可选。如果不配置此块，Docker client 会使用 Docker 的默认配置和环境变量，
     // 例如 DOCKER_HOST、DOCKER_TLS_VERIFY、DOCKER_CERT_PATH、DOCKER_API_VERSION。
@@ -54,6 +57,10 @@ halo {
 ```
 
 如需修改，你可以在 `build.gradle` 配置。
+
+如果需要同时为多个插件项目运行 `haloServer`，请为每个项目配置不同的 `port` 和
+`externalUrl`。如果启用了 debug 模式，也需要配置不同的 `debugPort`。只有需要自定义固定
+Docker 容器名时，才需要配置 `containerName`。
 
 ### haloServer 任务
 

--- a/src/main/java/run/halo/gradle/HaloDevtoolsPlugin.java
+++ b/src/main/java/run/halo/gradle/HaloDevtoolsPlugin.java
@@ -136,6 +136,15 @@ public class HaloDevtoolsPlugin implements Plugin<Project> {
                     }));
 
             String imageName = haloExtension.getImageName() + ":" + haloExtension.getVersion();
+            String defaultContainerName = DockerCreateContainer.defaultContainerName(
+                project.getName(),
+                project.getRootProject().getProjectDir(),
+                project.getPath()
+            );
+            String containerName = StringUtils.defaultIfBlank(
+                haloExtension.getContainerName(),
+                defaultContainerName
+            );
             project.getTasks().create("pullHaloImage", DockerPullImage.class, it -> {
                 it.getImage().set(imageName);
                 it.setGroup(GROUP);
@@ -146,7 +155,7 @@ public class HaloDevtoolsPlugin implements Plugin<Project> {
                 project.getTasks()
                     .create("createHaloContainer", DockerCreateContainer.class, it -> {
                         it.getImageId().set(imageName);
-                        it.getContainerName().set(haloExtension.getContainerName());
+                        it.getContainerName().set(containerName);
                         var workDir = pluginExtension.getWorkDir();
                         if (workDir.isPresent()) {
                             File dirFile = workDir.get().getAsFile();

--- a/src/main/java/run/halo/gradle/docker/DockerCreateContainer.java
+++ b/src/main/java/run/halo/gradle/docker/DockerCreateContainer.java
@@ -119,14 +119,39 @@ public class DockerCreateContainer extends AbstractOpenApiDocsTask {
             + "-containerId.txt";
     }
 
+    public static String defaultContainerName(String projectName, File rootDir, String projectPath) {
+        String name = sanitizeContainerNamePart(projectName);
+        String hashSource = canonicalPath(rootDir) + ":" + projectPath;
+        return "halo-" + name + "-" + sha256Hex(hashSource, 8);
+    }
+
     static String projectPathHash(String projectPath) {
+        return sha256Hex(projectPath, 8);
+    }
+
+    private static String sha256Hex(String value, int byteLength) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(projectPath.getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash, 0, 8);
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash, 0, byteLength);
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("SHA-256 is not available", e);
         }
+    }
+
+    private static String canonicalPath(File file) {
+        try {
+            return file.getCanonicalPath();
+        } catch (IOException e) {
+            return file.getAbsolutePath();
+        }
+    }
+
+    private static String sanitizeContainerNamePart(String name) {
+        String sanitized = StringUtils.defaultString(name)
+            .replaceAll("[^a-zA-Z0-9_.-]+", "-")
+            .replaceAll("^-+|-+$", "");
+        return StringUtils.defaultIfBlank(sanitized, "project");
     }
 
     private Spec<Task> getUpToDateWhenSpec() {

--- a/src/main/java/run/halo/gradle/extension/HaloExtension.java
+++ b/src/main/java/run/halo/gradle/extension/HaloExtension.java
@@ -27,7 +27,7 @@ public class HaloExtension {
 
     private String imageName = "halohub/halo";
 
-    private String containerName = "halo-for-plugin-development";
+    private String containerName;
 
     private String serverWorkDir = "/root/.halo2";
 

--- a/src/test/java/run/halo/gradle/docker/DockerCreateContainerTest.java
+++ b/src/test/java/run/halo/gradle/docker/DockerCreateContainerTest.java
@@ -2,6 +2,7 @@ package run.halo.gradle.docker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
 import org.junit.jupiter.api.Test;
 
 class DockerCreateContainerTest {
@@ -14,5 +15,54 @@ class DockerCreateContainerTest {
             .isEqualTo(".gradle/halo-devtools/containers/fe6d6407b0d4f368-containerId.txt");
         assertThat(DockerCreateContainer.containerIdFilePath(":plugins:app"))
             .isEqualTo(".gradle/halo-devtools/containers/ec3dced475b9eeff-containerId.txt");
+    }
+
+    @Test
+    void shouldBuildDefaultContainerNameFromProjectNameAndRootDir() {
+        String containerName = DockerCreateContainer.defaultContainerName(
+            "plugin-links",
+            new File("/workspace/plugin-links"),
+            ":"
+        );
+
+        assertThat(containerName).matches("halo-plugin-links-[0-9a-f]{16}");
+    }
+
+    @Test
+    void shouldUseDifferentContainerNamesForDifferentRootDirs() {
+        String firstContainerName = DockerCreateContainer.defaultContainerName(
+            "plugin-links",
+            new File("/workspace/plugin-links"),
+            ":"
+        );
+        String secondContainerName = DockerCreateContainer.defaultContainerName(
+            "plugin-links",
+            new File("/workspace/another-plugin-links"),
+            ":"
+        );
+
+        assertThat(firstContainerName).isNotEqualTo(secondContainerName);
+    }
+
+    @Test
+    void shouldSanitizeProjectNameForDefaultContainerName() {
+        String containerName = DockerCreateContainer.defaultContainerName(
+            "Halo 插件 / dev",
+            new File("/workspace/plugin"),
+            ":app"
+        );
+
+        assertThat(containerName).matches("halo-Halo-dev-[0-9a-f]{16}");
+    }
+
+    @Test
+    void shouldFallbackWhenProjectNameCannotBeUsedInDefaultContainerName() {
+        String containerName = DockerCreateContainer.defaultContainerName(
+            "插件",
+            new File("/workspace/plugin"),
+            ":app"
+        );
+
+        assertThat(containerName).matches("halo-project-[0-9a-f]{16}");
     }
 }


### PR DESCRIPTION
## Summary

- Generate the default haloServer container name from the Gradle project name, canonical root directory, and project path.
- Keep `halo.containerName` as an explicit override for users that need a fixed Docker name.
- Document multi-instance usage and add tests for generated container names.

## Why

The previous default container name was fixed as `halo-for-plugin-development`, so different plugin projects could not run `haloServer` at the same time even when they used different ports. Generating a deterministic name keeps Docker containers readable while avoiding cross-project name conflicts, and users can still opt into a fixed name with `halo.containerName` when needed.

## Testing

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew test`
- `git diff --check`
- Sibling plugin smoke with local plugin injected through a temporary Gradle init script:
  - `plugin-sitemap` -> `halo-plugin-sitemap-5fb390be3e63eb26`
  - `plugin-highlightjs` -> `halo-plugin-highlightjs-dbfa36eb5abad319`
  - `plugin-katex` -> `halo-plugin-katex-56e6485d006486fe`
  - `plugin-moments` -> `halo-plugin-moments-31e0f154ae1a2811`
  - `plugin-photos` -> `halo-plugin-photos-6cb7ff4b0fa95ec9`
  - `plugin-links` kept explicit override `plugin-links`
  - `SMOKE_OK auto_count=5 unique_auto_count=5`

```release-note
haloServer 启动的容器改为按规则生成容器名，不再固定
```
