### PR TITLE
Derive external URL from configured port

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ plugins {
 
 ## Tasks
 
-This plugin provides two tasks: `haloServer` and `watch`. To use these tasks, you need to have a Docker environment.
+This plugin provides three tasks: `haloServer`, `reloadPlugin`, and `watch`. To use these tasks, you need to have a Docker environment.
 
 For Windows and Mac users, you can directly install Docker Desktop. For Linux users, you can refer to the [official Docker documentation](https://docs.docker.com/engine/install/) to install Docker.
 
 After starting the Docker service, you can use the `haloServer` and `watch` tasks.
 
-These tasks will mount Halo's working directory to the `workplace` directory of the plugin project to ensure that data is not lost when restarting tasks.
+The `haloServer` and `watch` tasks will mount Halo's working directory to the `workplace` directory of the plugin project to ensure that data is not lost when restarting tasks.
 
 If you want to modify Halo's configuration, you can create a `config` directory under the `workplace` directory and add an `application.yaml` file. Then, add Halo's configuration in this file to override Halo's default configuration, for example:
 
@@ -43,7 +43,8 @@ halo {
     superAdminUsername = 'admin'
     superAdminPassword = 'admin'
     port = 8090
-    externalUrl = 'http://localhost:8090'
+    // Optional. Defaults to "http://localhost:${port}".
+    // externalUrl = 'https://halo.example.com'
     // Optional. By default, the container name is generated from the project
     // name, root directory, and Gradle project path.
     // containerName = 'halo-for-plugin-development'
@@ -63,9 +64,10 @@ halo {
 If needed, you can modify this configuration in `build.gradle`.
 
 When running `haloServer` for multiple plugin projects at the same time, configure
-different `port` and `externalUrl` values for each project. If debug mode is enabled,
-also configure different `debugPort` values. The `containerName` option is only needed
-when you want to use a custom fixed Docker container name.
+different `port` values for each project. The `externalUrl` value follows `port`
+automatically unless you override it. If debug mode is enabled, also configure
+different `debugPort` values. The `containerName` option is only needed when you want
+to use a custom fixed Docker container name.
 
 ### haloServer Task
 
@@ -75,12 +77,10 @@ Usage:
 ./gradlew haloServer
 ```
 
-This task is used to start the Halo service and automatically load the Halo plugin project using this Gradle plugin in development mode into the Halo service. However, after modifying the plugin, you need to stop this task and then re-execute it for the changes to take effect. Alternatively, you can use Halo's API to restart the plugin, which allows you to reload the plugin without stopping the `haloServer` task:
+This task is used to start the Halo service and automatically load the Halo plugin project using this Gradle plugin in development mode into the Halo service. However, after modifying the plugin, you need to stop this task and then re-execute it for the changes to take effect. Alternatively, you can use `reloadPlugin` to rebuild and reload the plugin without stopping the `haloServer` task:
 
 ```shell
-./gradlew clean build -x test
-# Replace {your-username} and {your-password} with Halo's username and password, and {your-plugin-name} with the plugin name
-curl -u {your-username}:{your-password} -X PUT http://localhost:8090/apis/api.console.halo.run/v1alpha1/plugins/{your-plugin-name}/reload
+./gradlew reloadPlugin
 ```
 
 ### watch Task

--- a/README_zh.md
+++ b/README_zh.md
@@ -16,13 +16,13 @@ plugins {
 
 ## 任务
 
-本插件提供了 haloServer 和 watch 两个任务，使用 haloServer 和 watch 这两个任务的前提条件是需要具有 Docker 环境。
+本插件提供了 haloServer、reloadPlugin 和 watch 三个任务，使用这些任务的前提条件是需要具有 Docker 环境。
 
 对于 Windows 和 Mac 用户，可以直接安装 Docker Desktop，对于 Linux 用户，可以参考 [Docker 官方文档](https://docs.docker.com/engine/install/) 安装 Docker。
 
 然后启动 Docker 服务，即可使用 haloServer 和 watch 任务。
 
-这两个任务会将 Halo 的工作目录挂在到插件项目的 `workplace` 目录下，以确保重启任务时不会丢失数据。
+`haloServer` 和 `watch` 任务会将 Halo 的工作目录挂在到插件项目的 `workplace` 目录下，以确保重启任务时不会丢失数据。
 
 如果你想要修改 Halo 的配置，可以在 `workplace` 目录下创建一个 `config` 目录并添加一个 `application.yaml` 文件，然后在此文件中添加 Halo 的配置以覆盖 Halo 的 `default` 配置, 如：
 
@@ -41,7 +41,8 @@ halo {
     superAdminUsername = 'admin'
     superAdminPassword = 'admin'
     port = 8090
-    externalUrl = 'http://localhost:8090'
+    // 可选。默认值为 "http://localhost:${port}"。
+    // externalUrl = 'https://halo.example.com'
     // 可选。默认会根据项目名称、根目录和 Gradle project path 自动生成容器名称。
     // containerName = 'halo-for-plugin-development'
 
@@ -58,9 +59,10 @@ halo {
 
 如需修改，你可以在 `build.gradle` 配置。
 
-如果需要同时为多个插件项目运行 `haloServer`，请为每个项目配置不同的 `port` 和
-`externalUrl`。如果启用了 debug 模式，也需要配置不同的 `debugPort`。只有需要自定义固定
-Docker 容器名时，才需要配置 `containerName`。
+如果需要同时为多个插件项目运行 `haloServer`，请为每个项目配置不同的 `port`。
+`externalUrl` 会默认跟随 `port` 自动推导，除非你显式覆盖它。如果启用了 debug 模式，
+也需要配置不同的 `debugPort`。只有需要自定义固定 Docker 容器名时，才需要配置
+`containerName`。
 
 ### haloServer 任务
 
@@ -72,12 +74,10 @@ Docker 容器名时，才需要配置 `containerName`。
 
 此任务用于启动 Halo 服务并自动将使用此 Gradle 插件的 Halo 插件项目以开发模式加载到 Halo 服务中。
 但当修改插件后，需要先停止此任务，然后再重新执行此任务才能生效。
-或者使用 Halo 提供的重启插件的 API, 这可以在不停止 haloServer 任务的情况下重新加载插件：
+或者使用 `reloadPlugin` 重新构建并加载插件，这可以在不停止 haloServer 任务的情况下完成：
 
 ```shell
-./gradlew clean build -x test
-# 替换 {your-username} 和 {your-password} 为 Halo 的用户名和密码, {your-plugin-name} 为插件的名称
-curl -u {your-username}:{your-password} -X PUT http://localhost:8090/apis/api.console.halo.run/v1alpha1/plugins/{your-plugin-name}/reload
+./gradlew reloadPlugin
 ```
 
 #### watch 任务

--- a/src/main/java/run/halo/gradle/extension/HaloExtension.java
+++ b/src/main/java/run/halo/gradle/extension/HaloExtension.java
@@ -3,6 +3,7 @@ package run.halo.gradle.extension;
 import javax.annotation.Nonnull;
 import lombok.Data;
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.file.RegularFileProperty;
@@ -33,7 +34,7 @@ public class HaloExtension {
 
     private String version = "2.9.1";
 
-    private String externalUrl = "http://localhost:8090";
+    private String externalUrl;
 
     private String superAdminUsername = "admin";
 
@@ -57,6 +58,11 @@ public class HaloExtension {
     @Nonnull
     public Integer getPort() {
         return ObjectUtils.defaultIfNull(port, 8090);
+    }
+
+    @Nonnull
+    public String getExternalUrl() {
+        return StringUtils.defaultIfBlank(externalUrl, "http://localhost:" + getPort());
     }
 
     @Nonnull

--- a/src/main/java/run/halo/gradle/steps/HaloSiteOption.java
+++ b/src/main/java/run/halo/gradle/steps/HaloSiteOption.java
@@ -1,7 +1,6 @@
 package run.halo.gradle.steps;
 
 import java.net.URI;
-import org.apache.commons.lang3.StringUtils;
 import run.halo.gradle.extension.HaloExtension;
 
 public record HaloSiteOption(String username, String password, URI externalUrl) {
@@ -9,8 +8,7 @@ public record HaloSiteOption(String username, String password, URI externalUrl) 
     public static HaloSiteOption from(HaloExtension extension) {
         var username = extension.getSuperAdminUsername();
         var password = extension.getSuperAdminPassword();
-        var externalUrl =
-            StringUtils.defaultIfBlank(extension.getExternalUrl(), "http://localhost:8090");
+        var externalUrl = extension.getExternalUrl();
         return new HaloSiteOption(username, password, URI.create(externalUrl));
     }
 }

--- a/src/test/java/run/halo/gradle/extension/HaloExtensionTest.java
+++ b/src/test/java/run/halo/gradle/extension/HaloExtensionTest.java
@@ -1,0 +1,55 @@
+package run.halo.gradle.extension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import run.halo.gradle.steps.HaloSiteOption;
+
+class HaloExtensionTest {
+
+    @Test
+    void defaultExternalUrlUsesDefaultPort() {
+        var extension = newExtension();
+
+        assertThat(extension.getExternalUrl()).isEqualTo("http://localhost:8090");
+        assertThat(HaloSiteOption.from(extension).externalUrl())
+            .hasToString("http://localhost:8090");
+    }
+
+    @Test
+    void externalUrlIsDerivedFromConfiguredPort() {
+        var extension = newExtension();
+        extension.setPort(8091);
+
+        assertThat(extension.getExternalUrl()).isEqualTo("http://localhost:8091");
+        assertThat(HaloSiteOption.from(extension).externalUrl())
+            .hasToString("http://localhost:8091");
+    }
+
+    @Test
+    void configuredExternalUrlOverridesDerivedUrl() {
+        var extension = newExtension();
+        extension.setPort(8091);
+        extension.setExternalUrl("https://halo.example.com");
+
+        assertThat(extension.getExternalUrl()).isEqualTo("https://halo.example.com");
+        assertThat(HaloSiteOption.from(extension).externalUrl())
+            .hasToString("https://halo.example.com");
+    }
+
+    @Test
+    void blankExternalUrlFallsBackToConfiguredPort() {
+        var extension = newExtension();
+        extension.setPort(8092);
+        extension.setExternalUrl(" ");
+
+        assertThat(extension.getExternalUrl()).isEqualTo("http://localhost:8092");
+        assertThat(HaloSiteOption.from(extension).externalUrl())
+            .hasToString("http://localhost:8092");
+    }
+
+    private static HaloExtension newExtension() {
+        return new HaloExtension(ProjectBuilder.builder().build().getObjects());
+    }
+}


### PR DESCRIPTION
## Summary

- Derive the default Halo `externalUrl` from the configured `port` instead of hard-coding `http://localhost:8090`.
- Keep explicit `externalUrl` values as overrides, including for `reloadPlugin` and other client calls through `HaloSiteOption`.
- Document `reloadPlugin` and the new `externalUrl` default behavior in both English and Chinese READMEs.

## Why

When developers changed `halo.port`, local Halo would run on the new port, but Gradle client tasks such as `reloadPlugin` still defaulted to `http://localhost:8090` unless `externalUrl` was also updated. That made the configuration easy to get wrong and the failure mode felt opaque.

## Tests

- `./gradlew test`
- `git diff --check`

```release-note
None
```