### PR TITLE
Support existing Halo server for OpenAPI generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ In the `build.gradle` file, use the `haloPlugin` block to configure settings rel
 haloPlugin {
     openApi {
         // outputDir = file("$rootDir/api-docs/openapi/v3_0") // Specify the output directory for OpenAPI documentation. By default, it outputs to the build directory. It is not recommended to modify this unless you need to commit it to the code repository.
+        // useExistingServer = false // Set to true to read from halo.externalUrl without starting the temporary OpenAPI docs container.
+        // apiDocsUrl = 'http://localhost:8090' // Optional. Override it only when reading from another existing Halo server.
         groupingRules {
             // Define API grouping rules to group APIs in the plugin project and generate API client code only for this group.
             // A group named extensionApis is defined. The task will access the API docs through /v3/api-docs/extensionApis and generate API client code.
@@ -245,6 +247,10 @@ const { data } = await momentsConsoleApiClient.moment.listTags({
 
 > [!NOTE]
 > It will first execute the `generateOpenApiDocs` task to access `/v3/api-docs/extensionApis` based on the configuration, retrieve the OpenAPI documentation, and save the schema file to the `openApi.outputDir` directory. Then, the `generateApiClient` task will generate API client code in the `openApi.generator.outputDir` directory based on the schema file.
+> If the API docs depend on other installed plugins, start and prepare Halo first,
+> then set `openApi.useExistingServer = true`. In this mode, `generateOpenApiDocs`
+> reads from `halo.externalUrl` by default and skips the temporary docs container.
+> Set `openApi.apiDocsUrl` only when reading from another Halo server URL.
 
 > [!WARNING]
 > Executing the `generateApiClient` task will first delete all files in the `openApi.generator.outputDir` directory. Therefore, it is recommended to set the output directory for the API client to a separate directory to avoid accidentally deleting other files.

--- a/README_zh.md
+++ b/README_zh.md
@@ -155,6 +155,8 @@ return SpringdocRouteBuilder.route()
 haloPlugin {
     openApi {
         // outputDir = file("$rootDir/api-docs/openapi/v3_0") // 指定 OpenAPI 文档的输出目录默认输出到 build 目录下，不建议修改，除非需要提交到代码仓库
+        // useExistingServer = false // 设为 true 时直接从 halo.externalUrl 读取，不启动临时 OpenAPI 文档容器。
+        // apiDocsUrl = 'http://localhost:8090' // 可选，仅在需要读取其他已有 Halo 服务时覆盖。
         groupingRules {
             // 定义 API 分组规则，用于为插件项目中的 APIs 分组然后只对此分组生成 API 客户端代码
             // 定义了一个名为 extensionApis 的分组，task 会通过 /v3/api-docs/extensionApis 访问到 api docs 然后生成 API 客户端代码
@@ -248,6 +250,9 @@ const { data } = await momentsConsoleApiClient.moment.listTags({
 > [!NOTE]
 > 它会先执行 `generateOpenApiDocs` 任务根据配置访问 `/v3/api-docs/extensionApis` 获取 OpenAPI 文档，
 > 并将 OpenAPI 的 Schema 文件保存到 `openApi.outputDir` 目录下，然后再由 `generateApiClient` 任务根据 Schema 文件生成 API 客户端代码到 `openApi.generator.outputDir` 目录下。
+> 如果 OpenAPI 文档依赖其他已安装插件，请先启动并准备好 Halo，然后设置
+> `openApi.useExistingServer = true`。此模式默认会从 `halo.externalUrl` 读取文档，
+> 并跳过临时文档容器；只有读取其他 Halo 服务时才需要设置 `openApi.apiDocsUrl`。
 
 > [!WARNING]
 > 执行 `generateApiClient` 任务时会先删除 `openApi.generator.outputDir` 下的所有文件，因此建议将 API client 的输出目录设置为一个独立的目录，以避免误删其他文件。

--- a/src/main/java/run/halo/gradle/HaloDevtoolsPlugin.java
+++ b/src/main/java/run/halo/gradle/HaloDevtoolsPlugin.java
@@ -213,7 +213,10 @@ public class HaloDevtoolsPlugin implements Plugin<Project> {
                 OpenApiDocsGeneratorTask.class, it -> {
                     it.setGroup(GROUP);
                     it.setDescription("Generate open api docs.");
-                    it.dependsOn("build", "pullHaloImage");
+                    it.dependsOn("build");
+                    if (!pluginExtension.getOpenApi().getUseExistingServer().get()) {
+                        it.dependsOn("pullHaloImage");
+                    }
                     it.getImageId().set(imageName);
                 });
 

--- a/src/main/java/run/halo/gradle/extension/OpenApiExtension.java
+++ b/src/main/java/run/halo/gradle/extension/OpenApiExtension.java
@@ -36,6 +36,7 @@ public class OpenApiExtension {
     private Property<String> apiDocsUrl;
     private Property<Integer> apiDocsPort;
     private Property<String> apiDocsVersion;
+    private Property<Boolean> useExistingServer;
 
     private ApiClientExtension generator;
 
@@ -54,6 +55,7 @@ public class OpenApiExtension {
         this.apiDocsUrl = objectFactory.property(String.class);
         this.apiDocsPort = objectFactory.property(Integer.class);
         this.apiDocsVersion = objectFactory.property(String.class);
+        this.useExistingServer = objectFactory.property(Boolean.class);
 
         this.generator = objectFactory.newInstance(ApiClientExtension.class);
         this.groupingRules = objectFactory.domainObjectContainer(GroupedOpenApiExtension.class,
@@ -66,6 +68,7 @@ public class OpenApiExtension {
         waitTimeInSeconds.convention(DEFAULT_WAIT_TIME_IN_SECONDS);
         this.apiDocsPort.convention(AvailablePortFinder.findRandomAvailablePort());
         this.apiDocsVersion.convention("OPENAPI_3_0");
+        this.useExistingServer.convention(false);
         conventionApiDocsUrl(extensions);
     }
 
@@ -79,11 +82,20 @@ public class OpenApiExtension {
 
     private void conventionApiDocsUrl(ExtensionContainer extensions) {
         var haloExtension = extensions.getByType(HaloExtension.class);
-        var externalUri = URI.create(haloExtension.getExternalUrl());
+        apiDocsUrl.convention(useExistingServer.map(useExisting -> {
+            if (useExisting) {
+                return haloExtension.getExternalUrl();
+            }
+            return createTemporaryApiDocsUrl(haloExtension.getExternalUrl(), apiDocsPort.get());
+        }));
+    }
+
+    private String createTemporaryApiDocsUrl(String externalUrl, int port) {
+        var externalUri = URI.create(externalUrl);
         try {
-            var uri = new URI(externalUri.getScheme(), null, externalUri.getHost(),
-                this.apiDocsPort.get(), null, null, null);
-            apiDocsUrl.convention(uri.toString());
+            var uri = new URI(externalUri.getScheme(), null, externalUri.getHost(), port, null,
+                null, null);
+            return uri.toString();
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Failed to create API docs URL", e);
         }

--- a/src/main/java/run/halo/gradle/openapi/CleanupApiServerContainer.java
+++ b/src/main/java/run/halo/gradle/openapi/CleanupApiServerContainer.java
@@ -2,6 +2,7 @@ package run.halo.gradle.openapi;
 
 import com.github.dockerjava.api.DockerClient;
 import javax.annotation.Nonnull;
+import org.gradle.api.Task;
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationDetails;
 import org.gradle.api.provider.Property;
 import org.gradle.api.services.BuildService;
@@ -45,8 +46,8 @@ public abstract class CleanupApiServerContainer
         @Nonnull OperationFinishEvent finishEvent) {
         Object details = buildOperation.getDetails();
         if (details instanceof ExecuteTaskBuildOperationDetails executeTaskDetails) {
-            String name = executeTaskDetails.getTask().getName();
-            if (!OpenApiDocsGeneratorTask.TASK_NAME.contains(name)) {
+            Task task = executeTaskDetails.getTask();
+            if (!shouldCleanup(task)) {
                 return;
             }
             DockerClientService dockerClientService =
@@ -65,6 +66,17 @@ public abstract class CleanupApiServerContainer
 
     DockerClient getDockerClient(DockerClientService dockerClientService) {
         return dockerClientService.getDockerClient(createDockerClientConfig(dockerClientService));
+    }
+
+    boolean shouldCleanup(Task task) {
+        String name = task.getName();
+        if (!OpenApiDocsGeneratorTask.TASK_NAME.equals(name)) {
+            return false;
+        }
+        if (task instanceof OpenApiDocsGeneratorTask openApiDocsGeneratorTask) {
+            return !openApiDocsGeneratorTask.getUseExistingServer().getOrElse(false);
+        }
+        return true;
     }
 
     private DockerClientConfiguration createDockerClientConfig(

--- a/src/main/java/run/halo/gradle/openapi/OpenApiDocsGeneratorTask.java
+++ b/src/main/java/run/halo/gradle/openapi/OpenApiDocsGeneratorTask.java
@@ -101,11 +101,15 @@ public class OpenApiDocsGeneratorTask extends AbstractOpenApiDocsTask {
     @Internal
     final Property<String> containerId = getProject().getObjects().property(String.class);
 
+    @Input
+    final Property<Boolean> useExistingServer = getProject().getObjects().property(Boolean.class);
+
     public OpenApiDocsGeneratorTask() {
         var openApi = getPluginExtension().getOpenApi();
         requestHeaders.convention(openApi.getRequestHeaders());
         waitTimeInSeconds.convention(openApi.getWaitTimeInSeconds());
         port.convention(openApi.getApiDocsPort());
+        useExistingServer.convention(openApi.getUseExistingServer());
     }
 
     @Override
@@ -120,25 +124,31 @@ public class OpenApiDocsGeneratorTask extends AbstractOpenApiDocsTask {
         if (Files.exists(outputFilePath)) {
             FileUtils.deleteRecursively(outputFilePath);
         }
+        if (useExistingServer.get()) {
+            generateApiDocs(outputDirFile);
+            return;
+        }
         try (var dockerClient = getDockerClient()) {
             prepareApiDocsServer(dockerClient);
-
-            var apiDocGenerator = ApiDocGenerator.builder()
-                .outputDir(outputDirFile)
-                .requestHeaders(requestHeaders.get())
-                .trustStore(trustStore)
-                .trustStorePassword(trustStorePassword)
-                .waitTimeInSeconds(waitTimeInSeconds.get())
-                .build();
-
-            System.out.println("Start generating API documentation...");
-            groupedApiMappings.get().forEach((k, v) -> {
-                var url = joinUrl(getApiDocsUrl().get(), k);
-                apiDocGenerator.generateApiDocs(url, v);
-            });
-
+            generateApiDocs(outputDirFile);
             removeContainer(dockerClient);
         }
+    }
+
+    private void generateApiDocs(File outputDirFile) {
+        var apiDocGenerator = ApiDocGenerator.builder()
+            .outputDir(outputDirFile)
+            .requestHeaders(requestHeaders.get())
+            .trustStore(trustStore)
+            .trustStorePassword(trustStorePassword)
+            .waitTimeInSeconds(waitTimeInSeconds.get())
+            .build();
+
+        System.out.println("Start generating API documentation...");
+        groupedApiMappings.get().forEach((k, v) -> {
+            var url = joinUrl(getApiDocsUrl().get(), k);
+            apiDocGenerator.generateApiDocs(url, v);
+        });
     }
 
     private String joinUrl(String baseUrl, String path) {

--- a/src/test/java/run/halo/gradle/extension/OpenApiExtensionTest.java
+++ b/src/test/java/run/halo/gradle/extension/OpenApiExtensionTest.java
@@ -1,0 +1,65 @@
+package run.halo.gradle.extension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+class OpenApiExtensionTest {
+
+    @Test
+    void apiDocsUrlDefaultsToApiDocsPortWhenUsingTemporaryServer() {
+        var project = newProject();
+        var halo = haloExtension(project);
+        halo.setPort(8091);
+
+        var openApi = openApiExtension(project);
+
+        URI apiDocsUri = URI.create(openApi.getApiDocsUrl().get());
+        assertThat(apiDocsUri.getScheme()).isEqualTo("http");
+        assertThat(apiDocsUri.getHost()).isEqualTo("localhost");
+        assertThat(apiDocsUri.getPort()).isEqualTo(openApi.getApiDocsPort().get());
+        assertThat(apiDocsUri.getPort()).isNotEqualTo(8091);
+    }
+
+    @Test
+    void apiDocsUrlDefaultsToHaloExternalUrlWhenUsingExistingServer() {
+        var project = newProject();
+        var halo = haloExtension(project);
+
+        var openApi = openApiExtension(project);
+        openApi.getUseExistingServer().set(true);
+        halo.setPort(8091);
+
+        assertThat(openApi.getApiDocsUrl().get()).isEqualTo("http://localhost:8091");
+    }
+
+    @Test
+    void explicitApiDocsUrlOverridesExistingServerDefault() {
+        var project = newProject();
+        haloExtension(project).setPort(8091);
+
+        var openApi = openApiExtension(project);
+        openApi.getUseExistingServer().set(true);
+        openApi.getApiDocsUrl().set("http://localhost:19090");
+
+        assertThat(openApi.getApiDocsUrl().get()).isEqualTo("http://localhost:19090");
+    }
+
+    private static Project newProject() {
+        return ProjectBuilder.builder().build();
+    }
+
+    private static HaloExtension haloExtension(Project project) {
+        return project.getExtensions()
+            .create(HaloExtension.EXTENSION_NAME, HaloExtension.class, project.getObjects());
+    }
+
+    private static OpenApiExtension openApiExtension(Project project) {
+        var pluginExtension = project.getExtensions()
+            .create(HaloPluginExtension.EXTENSION_NAME, HaloPluginExtension.class, project);
+        return pluginExtension.getOpenApi();
+    }
+}

--- a/src/test/java/run/halo/gradle/openapi/OpenApiDocsGeneratorTaskTest.java
+++ b/src/test/java/run/halo/gradle/openapi/OpenApiDocsGeneratorTaskTest.java
@@ -1,0 +1,79 @@
+package run.halo.gradle.openapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.concurrent.Executors;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import run.halo.gradle.extension.HaloExtension;
+import run.halo.gradle.extension.HaloPluginExtension;
+
+class OpenApiDocsGeneratorTaskTest {
+
+    @TempDir
+    File projectDir;
+
+    @Test
+    void shouldGenerateDocsFromExistingServerWithoutDockerClientService() throws Exception {
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            var executor = Executors.newSingleThreadExecutor();
+            try {
+                var requestLine = executor.submit(() -> handleOpenApiRequest(serverSocket));
+
+                var project = ProjectBuilder.builder().withProjectDir(projectDir).build();
+                project.getExtensions()
+                    .create(HaloExtension.EXTENSION_NAME, HaloExtension.class,
+                        project.getObjects());
+                var pluginExtension = project.getExtensions()
+                    .create(HaloPluginExtension.EXTENSION_NAME, HaloPluginExtension.class, project);
+                pluginExtension.setPluginName("test-plugin");
+
+                var openApi = pluginExtension.getOpenApi();
+                openApi.getUseExistingServer().set(true);
+                openApi.getApiDocsUrl().set("http://localhost:" + serverSocket.getLocalPort());
+                openApi.getGroupedApiMappings()
+                    .put("/v3/api-docs/extensionApis", "extensionApis.json");
+
+                var task = project.getTasks()
+                    .create(OpenApiDocsGeneratorTask.TASK_NAME, OpenApiDocsGeneratorTask.class);
+
+                task.runRemoteCommand();
+
+                var outputFile = openApi.getOutputDir().file("extensionApis.json").get().getAsFile();
+                assertThat(Files.readString(outputFile.toPath()))
+                    .contains("\"openapi\" : \"3.0.1\"");
+                assertThat(requestLine.get()).startsWith("GET /v3/api-docs/extensionApis ");
+            } finally {
+                executor.shutdownNow();
+            }
+        }
+    }
+
+    private static String handleOpenApiRequest(ServerSocket serverSocket) throws Exception {
+        try (var socket = serverSocket.accept();
+             var reader = new BufferedReader(new InputStreamReader(socket.getInputStream(),
+                 StandardCharsets.UTF_8))) {
+            var requestLine = reader.readLine();
+            String line;
+            while ((line = reader.readLine()) != null && !line.isBlank()) {
+                // Drain headers before writing the response.
+            }
+
+            byte[] body = "{\"openapi\":\"3.0.1\"}".getBytes(StandardCharsets.UTF_8);
+            byte[] headers = ("HTTP/1.1 200 OK\r\n"
+                + "Content-Type: application/json\r\n"
+                + "Content-Length: " + body.length + "\r\n\r\n")
+                .getBytes(StandardCharsets.UTF_8);
+            socket.getOutputStream().write(headers);
+            socket.getOutputStream().write(body);
+            return requestLine;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `haloPlugin.openApi.useExistingServer` so OpenAPI docs can be generated from an already-running Halo server.
- Default `openApi.apiDocsUrl` to `halo.externalUrl` when `useExistingServer` is enabled, while preserving the temporary-container URL behavior otherwise.
- Skip temporary OpenAPI docs container startup, image pulling, and cleanup when using an existing server.
- Document the new mode in both English and Chinese READMEs.

Closes #36.

## Validation

- `JAVA_HOME=/Users/ryanwang/Library/Java/JavaVirtualMachines/azul-17.0.16/Contents/Home ./gradlew test`
- `git diff --check`
- Verified against `halo-sigs/plugin-links` by starting `haloServer`, generating docs and API client from `http://localhost:8091`, and confirming no `halo-openapi-docs-generator` container was created.
