### PR TITLE
improvement: add Gradle Plugin Portal publishing workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,46 +1,38 @@
-name: Publish Halo Devtools Gradle Plugin to Maven
+name: Publish to Gradle Plugin Portal
 
 on:
   release:
     types: [published]
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Extract version from GitHub tag
         id: extract_version
         run: |
           tag_name=${{ github.event.release.tag_name }}
           VERSION=${tag_name#v}
-          echo "Extracted Version: $VERSION"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
-      - name: Build with Gradle
+      - name: Build and test
         run: ./gradlew clean build -Pversion=${{ env.VERSION }}
 
-      - name: Publish to Maven
+      - name: Publish to Gradle Plugin Portal
         env:
-          OSSR_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          OSSR_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-        run: ./gradlew publish -Pversion=${{ env.VERSION }}
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+        run: ./gradlew publishPlugins -Pversion=${{ env.VERSION }}


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

Replace the existing placeholder workflow with a functional Gradle Plugin Portal publishing workflow. The old workflow called `./gradlew publish` which only publishes to the internal `build/repo/internal` directory — not to any real repository.

Changes:
- Triggers on GitHub Release `published` event (unchanged)
- Replaces manual cache action with `gradle/actions/setup-gradle@v4` for automatic caching
- Upgrades `actions/checkout` and `actions/setup-java` from v3 to v4
- Runs `./gradlew clean build` before publishing (catches regressions)
- Calls `publishPlugins` instead of `publish` to actually ship to the Gradle Plugin Portal
- Uses `GRADLE_PUBLISH_KEY` + `GRADLE_PUBLISH_SECRET` secrets

#### Which issue(s) this PR fixes:

Fixes # N/A

#### Special notes for your reviewer:

需要仓库管理员在 Settings → Secrets and variables → Actions 中添加两个 secrets：
- `GRADLE_PUBLISH_KEY` — 从 [Gradle Plugin Portal](https://plugins.gradle.org/) 获取的 API Key
- `GRADLE_PUBLISH_SECRET` — 对应的 API Secret

#### Does this PR introduce a user-facing change?

```release-note
NONE
```