### PR TITLE
fix: configure signing for CI via in-memory PGP keys

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,6 +35,7 @@ jobs:
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
         run: ./gradlew publishPlugins -Pversion=${{ env.VERSION }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,4 +35,6 @@ jobs:
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
-        run: ./gradlew publishPlugins -Pversion=${{ env.VERSION }} -PskipSigning
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew publishPlugins -Pversion=${{ env.VERSION }}

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,16 @@ gradlePlugin {
 }
 
 signing {
-    required { !project.hasProperty('skipSigning') }
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    if (signingKey != null) {
+        def signingKeyId = findProperty("signingKeyId")
+        if (signingKeyId != null) {
+            useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+        } else {
+            useInMemoryPgpKeys(signingKey, signingPassword)
+        }
+    }
     sign publishing.publications
 }
 


### PR DESCRIPTION
## 问题

当前 signing 配置依赖默认的 file-based signatory，在 CI 环境中没有 keyring 文件，publishPlugins 会报 no configured signatory。

## 方案

按照 Gradle 官方文档推荐，使用 useInMemoryPgpKeys() 在 CI 中通过环境变量提供签名密钥：
- 有 signingKey property → 走内存签名（CI）
- 无 signingKey property → 回退默认 signatory（兼容本地 keyring）

## 前置条件

合并前需要在仓库 Secrets 中添加 SIGNING_KEY 和 SIGNING_PASSWORD。